### PR TITLE
Improved readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-R&Wbase-server
-==============
+# R&Wbase-server
 
 Fuseki-based implementation of a distributed versioned triple store.
 
-Install R&Wbase
-----------------
-Install the latest version of [OpenLink Virtuoso 6](https://github.com/openlink/virtuoso-opensource) first, or build it from [source](http://virtuoso.openlinksw.com/dataspace/doc/dav/wiki/Main/VOSMake) 
+## Install R&Wbase
+
+Install the latest version of [OpenLink Virtuoso 6](https://github.com/openlink/virtuoso-opensource) first, or build it from [source](http://virtuoso.openlinksw.com/dataspace/doc/dav/wiki/Main/VOSMake)
 
 WARNING: This implementation is NOT compatible with Virtuoso 7 due to its column-store architecture.
 
@@ -15,6 +14,7 @@ Next, run the script `install.sh` from `install/`. Be careful, installing R&Wbas
 The install script depends on the environment variable `RAWBASE_HOME` to be set and Virtuoso's `isql` command to be accessible. Both can also be supplied with command parameters.
 
 The following command parameters are optional:
+
 ```
     -i The path to the Virtuoso isql application
     -h The RAWBASE_HOME folder where the source is found
@@ -23,16 +23,25 @@ The following command parameters are optional:
     -p The Virtuoso pass, default dba
 ```
 
-Run R&Wbase
-----------------
+## Configure R&Wbase
+
+Before you run `rawbase-server`, there are 2 configuration files you should take a brief look at.
+
+1. In `config-rawbase.ttl`, ensure the settings match your current setup (esp. `fuvirtext:user` and `fuvirtext:password`).
+
+2. If you intend to use the web interface, copy the example configuration and update it as necessary
+
+```
+cp pages/rawbase/js/app/config.example.js pages/rawbase/js/app/config.js
+```
+
+
+## Run R&Wbase
 
 After R&Wbase has been installed, run it with the following command:
+
 ```
     ./rawbase-server.sh 8080
 ```
-The argument is optional and determines the port of the server. Default 3030
 
-To use the web interface, first copy the example configuration and update it as necessary.
-```
-    cp pages/rawbase/js/app/config.example.js pages/rawbase/js/app/config.js
-```
+The argument is optional and determines the port of the server. Default 3030

--- a/rawbase-server.sh
+++ b/rawbase-server.sh
@@ -8,7 +8,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-port=8080
+port=3030
 
 if [ ! -z "$1" ]
 then


### PR DESCRIPTION
Added an extra "Configure R&Wbase" section before "Run R&Wbase" and explicitely mention not only `config.js` but also the `config-rawbase.ttl` (which requires editing if Virtuoso is set up with a different `dba` user and password).

Also changed the default port in `rawbase-server.sh` to `3030` as originally described by the readme.
